### PR TITLE
Workaround broken submodule (for 5.0.4 update PR)

### DIFF
--- a/com.obsproject.Studio.Plugin.InputOverlay.yaml
+++ b/com.obsproject.Studio.Plugin.InputOverlay.yaml
@@ -22,8 +22,18 @@ modules:
         url: https://github.com/univrsal/input-overlay.git
         tag: v5.0.4
         commit: 5f18f42ecbb599b42ce0c4002a434835dd474cb0
+        disable-submodules: true # TODO: To remove next version
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)
       - type: file
         path: com.obsproject.Studio.Plugin.InputOverlay.metainfo.xml
+      # TODO: To remove next version
+      - type: git
+        dest: libuiohook
+        url: https://github.com/univrsal/libuiohook.git
+        commit: 63f62e0f5745b00a7c26930bbf5431760491f20e
+      - type: shell
+        commands:
+          - git config submodule.deps/libuiohook.url libuiohook
+          - git -c protocol.file.allow=always submodule update


### PR DESCRIPTION
@GeorgesStavracas asked if I could help off-thread, I create this PR to be sure that it does not get lost.

The libuiohook submodule points to a commit only present in the univrsal fork of the project.

It is fixed on the plugin master branch since it reuses the original repo.

**PS: If desired, you can change the target branch to master**