### PR TITLE
Update KDE SDK to 6.6

### DIFF
--- a/com.obsproject.Studio.Plugin.InputOverlay.yaml
+++ b/com.obsproject.Studio.Plugin.InputOverlay.yaml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.InputOverlay
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//6.5
+sdk: org.kde.Sdk//6.6
 build-extension: true
 separate-locales: false
 appstream-compose: false


### PR DESCRIPTION
Recent update to the OBS flatpak broke multiple plugins. Rebuilding with the latest KDE SDK should fix this issue.